### PR TITLE
Catch nil limit for floats

### DIFF
--- a/lib/active_record/connection_adapters/fb_adapter.rb
+++ b/lib/active_record/connection_adapters/fb_adapter.rb
@@ -884,7 +884,7 @@ module ActiveRecord
       end
 
       def float_to_sql(limit)
-        if limit <= 4
+        if limit.nil? || limit <= 4
           'float'
         else
           'double precision'


### PR DESCRIPTION
I had this line in a migration:
`add_column :locations, :latitude, :float`

When limit isn't supplied, limit is defaulted to nil. An error occurs when nil is compared with 4.
