### PR TITLE
add column_types method to the select_all result for rails 4 compatiblity

### DIFF
--- a/lib/active_record/connection_adapters/fb_adapter.rb
+++ b/lib/active_record/connection_adapters/fb_adapter.rb
@@ -35,7 +35,7 @@ module Arel
         "ROWS #{visit(o.expr)}"
       end
 
-      def visit_Arel_Nodes_Offseto o, a
+      def visit_Arel_Nodes_Offset o, a
         "SKIP #{visit(o.expr)}"
       end
 


### PR DESCRIPTION
initial patch from Ziaw for #5 and 
also    fixes #10  ArgumentError (wrong number of arguments (2 for 1) visit_Arel_Nodes_SelectStatement
