### PR TITLE
improve FbColumn#initialize so that limit, precision & scale get set only for correct column types

### DIFF
--- a/lib/active_record/connection_adapters/fb_adapter.rb
+++ b/lib/active_record/connection_adapters/fb_adapter.rb
@@ -830,6 +830,11 @@ module ActiveRecord
         add_column_sql = "ALTER TABLE #{quote_table_name(table_name)} ADD #{quote_column_name(column_name)} #{type_to_sql(type, options[:limit], options[:precision], options[:scale])}"
         add_column_options!(add_column_sql, options)
         execute(add_column_sql)
+        if options[:position]
+          # position is 1-based but add 1 to skip id column
+          alter_position_sql = "ALTER TABLE #{quote_table_name(table_name)} ALTER COLUMN #{quote_column_name(column_name)} POSITION #{options[:position] + 1}"
+          execute(alter_position_sql)
+        end
       end
 
       # Changes the column's definition according to the new options.


### PR DESCRIPTION
In FbColumn#initialize, @limit, @precision & @scale where always set.. this caused problems with the schema dump that gets update every time you run a migration (or rake db:schema:dump also). Some datatypes like integer, datetime, etc don't have a limit, precision or scale properties. Also, in the metadata tables of firebird the scale gets stored as negative.. so "field decimal(18, 2)" gets stored as (18, -2) and in the schema.db "t.decimal :precision => 18, :scale => -2" that fails when it gets run. 

I've also added a "position" option to add column so we are able to do "t.add_column :name, :datatype, { position: 1 }". That will do an "alter table XXX alter column YYY position ZZZ" sql statement after column creation.

Summarizing: 
- @limit gets set only for VARCHAR & BLOB
- @precision / @scale get set only for DECIMAL & NUMERIC
- @scale gets absoluted to become positive
- position option for add_column migration
