### PR TITLE
Add columns method to FbArray for select_all - Rails 4

### DIFF
--- a/lib/active_record/connection_adapters/fb_adapter.rb
+++ b/lib/active_record/connection_adapters/fb_adapter.rb
@@ -76,6 +76,11 @@ module ActiveRecord
       def column_types
         {}
       end
+      
+      def columns
+        self.first.keys
+      end
+
     end
 
     class FbColumn < Column # :nodoc:


### PR DESCRIPTION
The pluck method doesn't work because the 'columns' method isn't defined for the result object which is an FbArray.

The columns method is called at: https://github.com/rails/rails/blob/master/activerecord/lib/active_record/relation/calculations.rb#L154

Similar to #13
