### PR TITLE
Set clause in update statement can't contain table name

### DIFF
--- a/lib/active_record/connection_adapters/fb_adapter.rb
+++ b/lib/active_record/connection_adapters/fb_adapter.rb
@@ -80,7 +80,6 @@ module ActiveRecord
       def columns
         self.first.keys
       end
-
     end
 
     class FbColumn < Column # :nodoc:
@@ -518,6 +517,10 @@ module ActiveRecord
       def quote_column_name(column_name) # :nodoc:
         %Q("#{ar_to_fb_case(column_name.to_s)}")
       end
+
+      def quote_table_name_for_assignment(table, attr)
+        quote_column_name(attr)
+      end if ::ActiveRecord::VERSION::MAJOR >= 4
 
       # Quotes the table name. Defaults to column name quoting.
       # def quote_table_name(table_name)


### PR DESCRIPTION
AR4 includes the table name in the set clause of an update statement.

``` ruby
User.update_all(fname: "Test")
```

results in

``` sql
UPDATE "USERS" SET "USERS.FNAME" = ?, Test
```

Firebird can't have the table name in the set clause. SQLite can't either, so I stole the quote_table_name_for_assignment override from https://github.com/jruby/activerecord-jdbc-adapter/blob/master/lib/arjdbc/sqlite3/adapter.rb#L226-L228.
