### PR TITLE
fixed #change_column, add_column_options raising 'undefined method'

### DIFF
--- a/lib/active_record/connection_adapters/fb_adapter.rb
+++ b/lib/active_record/connection_adapters/fb_adapter.rb
@@ -850,7 +850,7 @@ module ActiveRecord
       #  change_column(:accounts, :description, :text)
       def change_column(table_name, column_name, type, options = {})
         sql = "ALTER TABLE #{quote_table_name(table_name)} ALTER COLUMN #{quote_column_name(column_name)} TYPE #{type_to_sql(type, options[:limit], options[:precision], options[:scale])}"
-        sql = add_column_options(sql, options)
+        add_column_options!(sql, options)
         execute(sql)
       end
 


### PR DESCRIPTION
In migrations, change_column wasn't working; I've changed #change_column behaviour to mimic #add_column related to add_column_options!.
