### PR TITLE
Use @config instead of @connection_params in FbAdapter

### DIFF
--- a/lib/active_record/connection_adapters/fb_adapter.rb
+++ b/lib/active_record/connection_adapters/fb_adapter.rb
@@ -257,9 +257,9 @@ module ActiveRecord
       @@boolean_domain = { :true => 1, :false => 0, :name => 'BOOLEAN', :type => 'integer' }
       cattr_accessor :boolean_domain
 
-      def initialize(connection, logger, connection_params=nil)
+      def initialize(connection, logger, config=nil)
         super(connection, logger)
-        @connection_params = connection_params
+        @config = config
         @visitor = Arel::Visitors::FB.new(self)
       end
 
@@ -343,7 +343,7 @@ module ActiveRecord
       # new connection with the database.
       def reconnect!
         disconnect!
-        @connection = Fb::Database.connect(@connection_params)
+        @connection = Fb::Database.connect(@config)
       end
 
       # Disconnects from the database if already connected. Otherwise, this


### PR DESCRIPTION
The initialize method of the adapter for [mysql](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L193), [pg](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L356), and [sqlite](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L130) sets a variable named `@config`. FbAdapter sets `@connection_params`.

This change will allow gems that expect the `@config` variable,  like [Octopus](https://github.com/tchandy/octopus/blob/master/lib/octopus/abstract_adapter.rb#L29) and [Multidb](https://github.com/atombender/multidb/blob/master/lib/multidb/configuration.rb#L42), to work.
