### PR TITLE
Update fb_adapter.rb

### DIFF
--- a/lib/active_record/connection_adapters/fb_adapter.rb
+++ b/lib/active_record/connection_adapters/fb_adapter.rb
@@ -3,7 +3,6 @@
 # Based originally on FireRuby extension by Ken Kunz <kennethkunz@gmail.com>
 
 require 'active_record/connection_adapters/abstract_adapter'
-# require 'active_support/core_ext/kernel/requires'
 require 'base64'
 
 module Arel


### PR DESCRIPTION
removed in 3.2
