### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: ruby
+
+rvm:
+  - 2.0.0-p247
+
+before_install:
+  - sudo apt-get install firebird2.5-superclassic firebird2.5-dev
+  - sudo sed 's/ENABLE_FIREBIRD_SERVER=no/ENABLE_FIREBIRD_SERVER=yes/g' /etc/default/firebird2.5 -i
+  - sudo service firebird2.5-superclassic start
+  - gem install bundler
+
+before_script:
+  - bundle update
+
+env:
+  matrix:
+    - "RAILS_VERSION=3.2.21"
+    - "RAILS_VERSION=4.0.13"
+    - "RAILS_VERSION=4.1.9"
+    - "RAILS_VERSION=4.2.0"
+
+script:
+  - bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
+gemspec
+
+gem 'bcrypt', '~> 3.1.7', require: false
 
 if ENV['RAILS_SOURCE']
   gemspec path: ENV['RAILS_SOURCE']
@@ -21,11 +24,4 @@ end
 
 if ENV['AREL']
   gem 'arel', path: ENV['AREL']
-end
-
-group :development do
-  gem 'bcrypt-ruby', '~> 3.0.0'
-  gem 'mocha'
-  gem 'minitest-spec-rails'
-  gem 'fb'
 end

--- a/RUNNING_TESTS.md
+++ b/RUNNING_TESTS.md
@@ -20,11 +20,7 @@ To bundle with your local clone of Rails:
 
 ## Configuring test databases
 
-By default, the tests will create a database in the project root directory in a folder called db. You'll need to first create this folder:
-
-`mkdir db && chmod o+w db`
-
-If you want to create your databases in a different folder, you can modify `test/config.yml`.
+By default, the tests will create a database in the project root directory in a folder called db. If you want to create your databases in a different folder, you can modify `test/config.yml`.
 
 ## Running the tests
 
@@ -39,3 +35,7 @@ To run only one test file:
 To run only a specific test:
 
 `bundle exec rake TESTOPTS="--name=/pattern_to_match_test_name/"`
+
+To run only the adapter's test suite:
+
+`bundle exec rake FB_ONLY=true`

--- a/activerecord-fb-adapter.gemspec
+++ b/activerecord-fb-adapter.gemspec
@@ -12,6 +12,9 @@ Gem::Specification.new do |s|
   s.has_rdoc = false
   s.files = Dir['README.md', 'lib/**/*']
 
-  s.add_dependency("fb", ">= 0.7.4")
-  s.add_dependency('activerecord', '>= 3.2.0')
+  s.add_dependency 'fb', '>= 0.7.4'
+  s.add_dependency 'activerecord', '>= 3.2.0'
+
+  s.add_development_dependency 'mocha'
+  s.add_development_dependency 'minitest-spec-rails'
 end

--- a/test/cases/fb_helper.rb
+++ b/test/cases/fb_helper.rb
@@ -24,9 +24,11 @@ require 'minitest-spec-rails/init/active_support'
 require 'minitest-spec-rails/init/mini_shoulda'
 require 'active_record/connection_adapters/fb_adapter'
 
-# Delete the old database files.
-db_files = Dir.glob(File.join(FB_ROOT, 'db', '*.fdb'))
-FileUtils.rm db_files if db_files.any?
+# Reset the db directory
+db_dir = File.join(FB_ROOT, 'db')
+FileUtils.rm_rf db_dir
+FileUtils.mkdir db_dir
+FileUtils.chmod 0777, db_dir
 
 module ActiveRecord::ConnectionAdapters
   # Can't handle decimal precision over 18, so force it as the max


### PR DESCRIPTION
This adds a `.travis.yml` file. To enable Travis CI for this repository, you'll need to login to Travis with your Github account and hit the 'ON' switch for this repo.

This will hopefully keep us better updated on the adapter's compatibility.