### PR TITLE
Add DatabaseTasks for Rails 4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ gem 'activerecord-fb-adapter'
 Then run:
 
 ```
-bundle update
+bundle install
 ```
 
-which will make bundler to get the gem with it's only dependency: the Fb gem which is "native" (has C code) and will be compiled the first time. Be sure you have a Firebird installation with access to the "ibase.h" file for this to succeed.
+Bundler will install the gem and it's dependency, Fb, which is "native" (has C code) and will be compiled the first time. Be sure you have a Firebird installation with access to the "ibase.h" file for this to succeed.
 
 4) Edit the **database.yml** for configuring your database connection:
 
@@ -50,7 +50,7 @@ development:
 
 The default Firebird administrator username and password are **SYSDBA** and **masterkey**, you may have to adjust this to your installation.
 
-Currently the adapter does not supports the "rake db:create" task, so in order to create the database you must add the "create: true" option; with this switch the first time the adapter tries to connect to the database it will be created if it doesn't exists.
+With the "create: true" option, a database will be created the first time the adapter tries to connect if it doesn't exist. Alternatively, if you're using Rails 4 or greater, you can use the "rake db:create" task.
 
 5) Start the rails server in development mode
 

--- a/lib/active_record/connection_adapters/fb/database_statements.rb
+++ b/lib/active_record/connection_adapters/fb/database_statements.rb
@@ -113,7 +113,7 @@ module ActiveRecord
         # column values as values. ActiveRecord >= 4 returns an ActiveRecord::Result.
         def select(sql, name = nil, binds = [])
           result = exec_query(sql, name, binds)
-          ActiveRecord::VERSION::MAJOR > 3 ? result : result.to_a
+          ::ActiveRecord::VERSION::MAJOR > 3 ? result : result.to_a
         end
 
         # Since the ID is prefetched and passed to #insert, this method is useless.

--- a/lib/active_record/connection_adapters/fb/schema_statements.rb
+++ b/lib/active_record/connection_adapters/fb/schema_statements.rb
@@ -81,7 +81,7 @@ module ActiveRecord
 
         # Unfortunately, this is a limitation of Firebird.
         def rename_table(name, new_name)
-          fail 'Firebird does not support renaming tables.'
+          fail ActiveRecordError, 'Firebird does not support renaming tables.'
         end
 
         def drop_table(name, options = {}) # :nodoc:
@@ -143,7 +143,7 @@ module ActiveRecord
         end
 
         def change_column_null(table_name, column_name, null, default = nil)
-          fail 'Firebird cannot change the nullability of a column using ALTER COLUMN.'
+          fail ActiveRecordError, 'Firebird cannot change the nullability of a column using ALTER COLUMN.'
         end
 
         # Renames a column.
@@ -187,11 +187,11 @@ module ActiveRecord
           end
           # must explicitly check for :null to allow change_column to work on migrations
           sql << ' NOT NULL' if options[:null] == false
-        end if ActiveRecord::VERSION::MAJOR > 3
+        end if ::ActiveRecord::VERSION::MAJOR > 3
 
         private
 
-        if ActiveRecord::VERSION::MAJOR > 3
+        if ::ActiveRecord::VERSION::MAJOR > 3
           def create_table_definition(*args)
             TableDefinition.new(native_database_types, *args)
           end
@@ -224,7 +224,7 @@ module ActiveRecord
         # Creates a domain for boolean fields as needed
         def while_ensuring_boolean_domain(&block)
           block.call
-        rescue ActiveRecord::StatementInvalid => e
+        rescue ::ActiveRecord::StatementInvalid => e
           raise unless e.message =~ /Specified domain or source column \w+ does not exist/
           create_boolean_domain
           block.call

--- a/lib/active_record/connection_adapters/fb_adapter.rb
+++ b/lib/active_record/connection_adapters/fb_adapter.rb
@@ -2,6 +2,7 @@
 # Author: Brent Rowland <rowland@rowlandresearch.com>
 # Based originally on FireRuby extension by Ken Kunz <kennethkunz@gmail.com>
 
+require 'fb'
 require 'base64'
 require 'arel'
 require 'arel/visitors/fb'

--- a/lib/active_record/connection_adapters/fb_column.rb
+++ b/lib/active_record/connection_adapters/fb_column.rb
@@ -30,7 +30,7 @@ module ActiveRecord
       def default
         if @default
           sql = "SELECT CAST(#{@default} AS #{column_def}) FROM RDB$DATABASE"
-          connection = ActiveRecord::Base.connection
+          connection = ::ActiveRecord::Base.connection
           if connection
             value = connection.raw_connection.query(:hash, sql)[0]['cast']
             return nil if value.acts_like?(:date) || value.acts_like?(:time)

--- a/lib/active_record/fb_base.rb
+++ b/lib/active_record/fb_base.rb
@@ -18,7 +18,7 @@ module ActiveRecord
     end
 
     def self.fb_connection_config(config)
-      config = config.symbolize_keys.reverse_merge(:downcase_names => true, :port => 3050)
+      config = config.symbolize_keys.dup.reverse_merge(:downcase_names => true, :port => 3050)
       fail ArgumentError, 'No database specified. Missing argument: database.' if !config[:database]
       if config[:host].nil? || config[:host] =~ /localhost/i
         config[:database] = File.expand_path(config[:database], defined?(Rails) && Rails.root)

--- a/lib/active_record/tasks/fb_database_tasks.rb
+++ b/lib/active_record/tasks/fb_database_tasks.rb
@@ -1,0 +1,75 @@
+module ActiveRecord
+  module Tasks # :nodoc:
+    class FbDatabaseTasks # :nodoc:
+      delegate :fb_connection_config, :establish_connection, to: ::ActiveRecord::Base
+
+      def initialize(configuration, root = ::ActiveRecord::Tasks::DatabaseTasks.root)
+        @root, @configuration = root, fb_connection_config(configuration)
+      end
+
+      def create
+        fb_database.create
+        establish_connection configuration
+      rescue ::Fb::Error => e
+        raise unless e.message.include?('database or file exists')
+        raise DatabaseAlreadyExists
+      end
+
+      def drop
+        fb_database.drop
+      rescue ::Fb::Error => e
+        raise ::ActiveRecord::ConnectionNotEstablished, e.message
+      end
+
+      def purge
+        drop
+        create
+      end
+
+      def structure_dump(filename)
+        isql :extract, output: filename
+      end
+
+      def structure_load(filename)
+        isql input: filename
+      end
+
+      private
+
+      def fb_database
+        ::Fb::Database.new(configuration)
+      end
+
+      # Executes isql commands to load/dump the schema.
+      # The generated command might look like this:
+      #   isql db/development.fdb -user SYSDBA -password masterkey -extract
+      def isql(*args)
+        opts = args.extract_options!
+        user, pass = configuration.values_at(:username, :password)
+        user ||= configuration[:user]
+        opts.reverse_merge!(user: user, password: pass)
+        cmd = [isql_executable, configuration[:database]]
+        cmd += opts.map { |name, val| "-#{name} #{val}" }
+        cmd += args.map { |flag| "-#{flag}" }
+        cmd = cmd.join(' ')
+        raise "Error running: #{cmd}" unless Kernel.system(cmd)
+      end
+
+      # Finds the isql command line utility from the PATH
+      # Many linux distros call this program isql-fb, instead of isql
+      def isql_executable
+        require 'mkmf'
+        exe = ['isql-fb', 'isql'].detect { |c| find_executable0(c) }
+        exe || abort("Unable to find isql or isql-fb in your $PATH")
+      end
+
+      def configuration
+        @configuration
+      end
+
+      def root
+        @root
+      end
+    end
+  end
+end

--- a/lib/activerecord-fb-adapter.rb
+++ b/lib/activerecord-fb-adapter.rb
@@ -1,0 +1,14 @@
+require 'active_record/connection_adapters/fb_adapter'
+
+module ActiveRecordFbAdapter
+
+  if defined?(::Rails::Railtie) && ::ActiveRecord::VERSION::MAJOR > 3
+    class Railtie < ::Rails::Railtie
+      rake_tasks do
+        load 'active_record/tasks/fb_database_tasks.rb'
+        ActiveRecord::Tasks::DatabaseTasks.register_task /fb/, ActiveRecord::Tasks::FbDatabaseTasks
+      end
+    end
+  end
+
+end

--- a/test/cases/database_tasks_test_fb.rb
+++ b/test/cases/database_tasks_test_fb.rb
@@ -1,0 +1,73 @@
+# encoding: UTF-8
+
+require 'cases/fb_helper'
+require 'fileutils'
+
+# This error class is loaded after the tasks start to run. It is defined here
+# simply so that it can be referenced in the test
+class ActiveRecord::Tasks::DatabaseAlreadyExists < StandardError; end
+
+class DatabaseTasksTestFb < Minitest::Test
+  def setup
+    ar_config = YAML.load ERB.new(File.read(ENV['ARCONFIG'])).result
+    @config = ar_config['fbunit_tasks']
+    database_tasks.stubs(:isql_executable).returns('isql')
+    database_tasks.stubs(:establish_connection)
+  end
+
+  def teardown
+    FileUtils.rm fdb_file if File.exist?(fdb_file)
+  end
+
+  def test_create_database
+    assert !File.exist?(fdb_file)
+    database_tasks.create
+    assert File.exist?(fdb_file)
+  end
+
+  def test_create_database_when_exists
+    database_tasks.create
+    assert File.exist?(fdb_file)
+    assert_raises ActiveRecord::Tasks::DatabaseAlreadyExists do
+      database_tasks.create
+    end
+  end
+
+  def test_drop_database
+    database_tasks.create
+    assert File.exist?(fdb_file)
+    database_tasks.drop
+    assert !File.exist?(fdb_file)
+  end
+
+  def test_drop_database_when_not_exists
+    assert !File.exist?(fdb_file)
+    assert_raises ActiveRecord::ConnectionNotEstablished do
+      database_tasks.drop
+    end
+  end
+
+  def test_structure_dump
+    expr = /isql(.+)-output FILE(.+)-user(.+)-password(.+) -extract/
+    Kernel.expects(:system).with(regexp_matches(expr)).returns(true)
+    database_tasks.create
+    database_tasks.structure_dump('FILE')
+  end
+
+  def test_structure_load
+    expr = /isql(.+)-input FILE(.+)-user(.+)-password(.+)/
+    Kernel.expects(:system).with(regexp_matches(expr)).returns(true)
+    database_tasks.create
+    database_tasks.structure_load('FILE')
+  end
+
+  private
+
+  def fdb_file
+    File.expand_path @config['database'], FB_ROOT
+  end
+
+  def database_tasks
+    @tasks ||= ActiveRecord::Tasks::FbDatabaseTasks.new(@config, FB_ROOT)
+  end
+end if ::ActiveRecord::VERSION::MAJOR > 3

--- a/test/cases/fb_helper.rb
+++ b/test/cases/fb_helper.rb
@@ -23,6 +23,7 @@ require 'minitest-spec-rails'
 require 'minitest-spec-rails/init/active_support'
 require 'minitest-spec-rails/init/mini_shoulda'
 require 'active_record/connection_adapters/fb_adapter'
+require 'active_record/tasks/fb_database_tasks'
 
 # Delete the old database files.
 db_files = Dir.glob(File.join(FB_ROOT, 'db', '*.fdb'))

--- a/test/config.yml
+++ b/test/config.yml
@@ -17,3 +17,8 @@ connections:
     arunit2:
       <<: *default_connection_info
       database: db/activerecord_unittest2.fdb
+
+fbunit_tasks:
+  <<: *default_connection_info
+  database: db/fb_tasks_test.fdb
+  create: false


### PR DESCRIPTION
Adds rake tasks for firebird to Rails 4+. Rails 3's rake tasks aren't as easy to hook into, so I decided not to worry about it.

+ `rake db:create`
+ `rake db:drop`
+ `rake db:purge`
+ `rake db:structure:dump`
+ `rake db:structure:load`

Not sure if these tasks would all work for remote databases.