### PR TITLE
Allow configuration of transaction isolation

### DIFF
--- a/lib/active_record/connection_adapters/fb/database_statements.rb
+++ b/lib/active_record/connection_adapters/fb/database_statements.rb
@@ -54,7 +54,23 @@ module ActiveRecord
 
         # Begins the transaction (and turns off auto-committing).
         def begin_db_transaction
-          @connection.transaction('READ COMMITTED')
+          begin_isolated_db_transaction(default_transaction_isolation)
+        end
+
+        # Default isolation levels for transactions. This method exists
+        # in 4.0.2+, so it's here for backward compatibility with AR 3
+        def transaction_isolation_levels
+          {
+            read_committed:   "READ COMMITTED",
+            repeatable_read:  "REPEATABLE READ",
+            serializable:     "SERIALIZABLE"
+          }
+        end
+
+        # Allows providing the :transaction option to ActiveRecord::Base.transaction
+        # in 4.0.2+. Can accept verbatim isolation options like 'WAIT READ COMMITTED'
+        def begin_isolated_db_transaction(isolation)
+          @connection.transaction transaction_isolation_levels.fetch(isolation, isolation)
         end
 
         # Commits the transaction (and turns on auto-committing).

--- a/lib/active_record/connection_adapters/fb_adapter.rb
+++ b/lib/active_record/connection_adapters/fb_adapter.rb
@@ -128,6 +128,9 @@ module ActiveRecord
       @@boolean_domain = { :true => 1, :false => 0, :name => 'BOOLEAN', :type => 'integer' }
       cattr_accessor :boolean_domain
 
+      @@default_transaction_isolation = :read_committed
+      cattr_accessor :default_transaction_isolation
+
       class BindSubstitution < Arel::Visitors::Fb # :nodoc:
         include Arel::Visitors::BindVisitor
       end
@@ -172,6 +175,10 @@ module ActiveRecord
       # SQL Server, and others support this.  MySQL and others do not.
       def supports_ddl_transactions?
         false
+      end
+
+      def supports_transaction_isolation?
+        true
       end
 
       # Does this adapter support savepoints? FirebirdSQL does


### PR DESCRIPTION
I just had a nasty problem with deadlocking in my application. I needed a little bit more control over transaction isolation.

AbstractAdapter has a method called `#begin_isolated_db_transaction` which allows you to do the following:

```ruby
ActiveRecord::Base.transaction(isolation: :repeatable_read) { }
```

If you need a little more control, say for example you want to use WAIT transactions, you can do this:

```ruby
ActiveRecord::Base.transaction(isolation: 'WAIT READ COMMITTED') { }
```

By default, this adapter uses `READ COMMITTED` transactions. I've added an accessor to allow you to change that as well by adding the following to an initializer:

```ruby
ActiveRecord::ConnectionAdapters::FbAdapter.default_transaction_isolation = :serializable
```