### PR TITLE
Don't raise an error when drop fails in purge

### DIFF
--- a/lib/active_record/tasks/fb_database_tasks.rb
+++ b/lib/active_record/tasks/fb_database_tasks.rb
@@ -22,7 +22,7 @@ module ActiveRecord
       end
 
       def purge
-        drop
+        drop rescue nil
         create
       end
 


### PR DESCRIPTION
If your test database doesn't already exist, `rake db:test:prepare` fails because drop raises an error. We can safely ignore the error in purge.